### PR TITLE
optimize docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,26 @@
-FROM golang
-
-EXPOSE 8080
-
-VOLUME [ "./db/", "./conf/" ]
-
-WORKDIR "linkmc/"
-# download all the modules
+FROM golang AS builder
 
 RUN go get go.etcd.io/bbolt/...
 
 COPY . .
 
+ENV GOPATH "${WORKDIR}"
+
 RUN go mod vendor
 
-RUN go install .
+RUN go build
 
-ENTRYPOINT [ "linkmc" ]
+FROM alpine
+
+RUN apk add --no-cache libc6-compat
+
+# expose the port
+EXPOSE 8080
+
+VOLUME [ "/data" ]
+
+WORKDIR "linkmc/"
+
+
+COPY --from=builder "/go/linkmc" .
+ENTRYPOINT [ "./linkmc" ]

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	configFlag = flag.String("config", "conf/config.toml", "Set the config path to use for the application")
+	configFlag = flag.String("config", "/data/conf/config.toml", "Set the config path to use for the application")
 
 	conf *config.Config
 


### PR DESCRIPTION
The current docker build was nearly 1GB! This was due to packaging all the necessary build tools. We really only need the binary file (and a volume for a persistent DB & config). By building in an intermediary container and copying the binary over to a much lighter one, we were able to reduce the container build from 1GB to just 16MB